### PR TITLE
TrueSkill rankings for openings

### DIFF
--- a/card_info.py
+++ b/card_info.py
@@ -39,6 +39,9 @@ def VPPerCard(singular_card_name):
 def IsTreasure(singular_card_name):
     return _card_info_rows[singular_card_name]['Treasure'] == '1'
 
+def Cost(singular_card_name):
+    return _card_info_rows[singular_card_name]['Cost']
+
 # Returns value of card name if the value is unambigous.
 def MoneyValue(card_name):
     try:
@@ -69,6 +72,10 @@ def NumCopiesPerGame(card_name, num_players):
 
 EVERY_SET_CARDS = ['Estate', 'Duchy', 'Province',
                    'Copper', 'Silver', 'Gold', 'Curse']
+
+OPENING_CARDS = [card for card in _card_info_rows
+                 if Cost(card) in ('0', '2', '3', '4', '5')]
+OPENING_CARDS.sort()
 
 def CardIndex(singular):
     return _card_index[singular]

--- a/frontend.py
+++ b/frontend.py
@@ -98,8 +98,9 @@ class OpeningPage:
         else:
             query = db.trueskill_openings.find({})
 
-        offset = db.trueskill_openings.find_one({'name':
-            'open:Silver+Silver'})['mu']
+        #offset = db.trueskill_openings.find_one({'name':
+        #    'open:Silver+Silver'})['mu']
+        offset = 0
         openings = list(query)
         card_list = card_info.OPENING_CARDS
         for opening in openings:

--- a/frontend.py
+++ b/frontend.py
@@ -65,9 +65,9 @@ class PopularBuyPage:
 
 def make_level_str(floor, ceil):
     if ceil < 0:
-        return '-%d' % (-ceil)
+        return '-%d' % (-ceil + 1)
     elif floor > 0:
-        return '+%d' % (floor)
+        return '+%d' % (floor + 1)
     else:
         return '0'
 
@@ -88,11 +88,12 @@ class OpeningPage:
         web.header("Content-Type", "text/html; charset=utf-8")  
         query_dict = dict(urlparse.parse_qsl(web.ctx.env['QUERY_STRING']))
         db = utils.get_mongo_database()
+        selected_card = ''
+
         if 'card' in query_dict:
             selected_card = query_dict['card']
-        else:
-            selected_card = 'All cards'
-        if selected_card != 'All cards':
+
+        if selected_card not in ('All cards', ''):
             query = db.trueskill_openings.find({'cards': selected_card})
         else:
             query = db.trueskill_openings.find({})
@@ -120,6 +121,10 @@ class OpeningPage:
 
         openings.sort(key=lambda opening: opening['level_key'])
         openings.reverse()
+        if selected_card == '':
+            openings = [op for op in openings
+                        if op['level_key'][0] != 0
+                        or op['cards'] == ['Silver', 'Silver']]
     
         render = web.template.render('')
         return render.openings_template(openings, card_list, selected_card)

--- a/index.html
+++ b/index.html
@@ -51,6 +51,9 @@
     <div class="cardborder yellow">
       <a href="/popular_buys">popular buys</a>
     </div>
+    <div class="cardborder yellow">
+      <a href="/openings">best and worst openings</a>
+    </div>
     <div style="clear: both;">&nbsp;</div>
 
     <h2 class="treasure">Suggestions</h2>       

--- a/openings_template.html
+++ b/openings_template.html
@@ -1,0 +1,82 @@
+$def with ( openings, card_list, selected_card )
+<html><head>
+<title>Best and Worst Openings</title>
+<style>
+body { font-family: sans-serif; color: #222; }
+table { border-collapse: collapse; }
+td { padding: 3px 15px; }
+tr.level td { border-top: 1px solid #ccc; }
+tr.level td.level { font-weight: bold; color: #000; }
+.lremind { color: #ccc; }
+.c { text-align: center; }
+.up { color: #0c0; font-size: 84%; text-align: center; padding-left: 2ex; }
+.down { color: #c00; font-size: 84%; text-align: center; padding-left: 2ex; }
+b { font-weight: bold; color: #000; }
+.sm { font-size: 70.7%; }
+.c2 { text-align: center; font-size: 70.7%; color: #339; }
+.indeterminate { background-color: #ccc; }
+</style>
+</head>
+<body>
+<h1>Best and Worst Openings</h1>
+<p>This page is meant to be reminiscent of the
+<a href="http://dominion.isotropic.org/leaderboard">Isotropic leaderboard</a>.
+We consider the <i>openings</i> -- the cards you buy on the first two turns --
+as if they were players whose skill adds to yours. The "level" of an opening
+then indicates the minimum amount it should add, or subtract, from your
+effective level.</p>
+<p>We define Silver/Silver to have a skill of 0. The many openings that have
+not distinguished themselves from Silver/Silver (which appear in gray between
+"level +0" and "level -0") are sorted by average skill instead of level.</p>
+<p>(This page will probably go down when it's merged into the main
+councilroom.com.)</p>
+<form action="/openings" method="get">
+<label for="card">Filter for card:</label>
+<select name="card">
+<option>All cards</option>
+$for card in card_list:
+    $if card == selected_card:
+        <option selected>$card</option>
+    $else:
+        <option>$card</option>
+</select>
+<input type="submit" value="Go">
+</form>
+$ samelevel = 0
+$ prevlevel = '-'
+$ rank = 0
+<table>
+<tr><th></th><th>skill range</th><th>rank</th><th>cards</th><th>cost</th></tr>
+$for opening in openings:
+    $code:
+        level = opening['level_str']
+        if level == prevlevel:
+            samelevel += 1
+        else:
+            samelevel = 0
+        rank += 1
+    $if (level == '0'):
+        $if (prevlevel.startswith('+')):
+            <tr class='blank'> 
+            <td></td> <td>&nbsp;</td> <td></td> <td></td> <td></td>
+            </tr>
+        <tr class='indeterminate'> <td></td>
+    $elif (samelevel == 0):
+        $if (level.startswith('-') and prevlevel == '0'):
+            <tr class='blank'> 
+            <td></td> <td>&nbsp;</td> <td></td> <td></td> <td></td>
+            </tr>
+        <tr class='level'><td class='level'>Level $level</td>
+    $elif (samelevel % 10 == 0):
+        <tr><td class='lremind'>Level $level</td>
+    $else:
+        <tr><td></td>
+    $ prevlevel = level
+    <td>$:opening['skill_str']</td>
+    <td class='c2'>$rank</td>
+    <td>$(' / '.join(opening['cards']))</td>
+    <td>$opening['cost']</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/openings_template.html
+++ b/openings_template.html
@@ -25,8 +25,11 @@ We consider the <i>openings</i> -- the cards you buy on the first two turns --
 as if they were players whose skill adds to yours. The "level" of an opening
 then indicates the minimum amount it should add, or subtract, from your
 effective level, rounded up.</p>
-<p>We define Silver/Silver to have a skill of 0. The gray box in the middle
-represents "level 0", the many openings that are not yet distinguishable from Silver/Silver. To see these openings, search for a particular card or "All cards".</p>
+<p>
+There are many openings of average or unknown effectiveness in level 0.
+They're hidden by default, but they will show up when you search for a
+particular card or "All cards".
+</p>
 <p>(This URL, on :8001, will probably go down when it's merged into the main
 councilroom.com.)</p>
 <form action="/openings" method="get">
@@ -63,7 +66,10 @@ $for opening in openings:
                 <tr class='indeterminate'> 
                 <td></td> <td></td> <td></td> <td>...</td> <td></td>
                 </tr>
-        <tr class='indeterminate'> <td></td>
+        $if (samelevel == 0):
+            <tr class='indeterminate level'><td class='level'>Level 0</td>
+        $else:
+            <tr class='indeterminate'><td></td>
     $elif (samelevel == 0):
         $if (level.startswith('-') and prevlevel == '0'):
             $if selected_card == '':

--- a/openings_template.html
+++ b/openings_template.html
@@ -24,11 +24,10 @@ b { font-weight: bold; color: #000; }
 We consider the <i>openings</i> -- the cards you buy on the first two turns --
 as if they were players whose skill adds to yours. The "level" of an opening
 then indicates the minimum amount it should add, or subtract, from your
-effective level.</p>
-<p>We define Silver/Silver to have a skill of 0. The many openings that have
-not distinguished themselves from Silver/Silver (which appear in gray between
-"level +0" and "level -0") are sorted by average skill instead of level.</p>
-<p>(This page will probably go down when it's merged into the main
+effective level, rounded up.</p>
+<p>We define Silver/Silver to have a skill of 0. The gray box in the middle
+represents "level 0", the many openings that are not yet distinguishable from Silver/Silver. To see these openings, search for a particular card or "All cards".</p>
+<p>(This URL, on :8001, will probably go down when it's merged into the main
 councilroom.com.)</p>
 <form action="/openings" method="get">
 <label for="card">Filter for card:</label>
@@ -60,9 +59,17 @@ $for opening in openings:
             <tr class='blank'> 
             <td></td> <td>&nbsp;</td> <td></td> <td></td> <td></td>
             </tr>
+            $if selected_card == '':
+                <tr class='indeterminate'> 
+                <td></td> <td></td> <td></td> <td>...</td> <td></td>
+                </tr>
         <tr class='indeterminate'> <td></td>
     $elif (samelevel == 0):
         $if (level.startswith('-') and prevlevel == '0'):
+            $if selected_card == '':
+                <tr class='indeterminate'> 
+                <td></td> <td></td> <td></td> <td>...</td> <td></td>
+                </tr>
             <tr class='blank'> 
             <td></td> <td>&nbsp;</td> <td></td> <td></td> <td></td>
             </tr>
@@ -73,7 +80,10 @@ $for opening in openings:
         <tr><td></td>
     $ prevlevel = level
     <td>$:opening['skill_str']</td>
-    <td class='c2'>$rank</td>
+    <td class='c2'>
+    $if level.startswith('+'):
+        $rank
+    </td>
     <td>$(' / '.join(opening['cards']))</td>
     <td>$opening['cost']</td>
     </tr>

--- a/run_trueskill.py
+++ b/run_trueskill.py
@@ -91,6 +91,8 @@ def update_plays():
     for opening in DB.trueskill_openings.find():
         key = opening['name']
         cards = key[5:].split('+')
+        if cards == ['']:
+            cards = []
         print cards
         DB.trueskill_openings.update(
             {'name': key},

--- a/run_trueskill.py
+++ b/run_trueskill.py
@@ -86,3 +86,14 @@ def run_trueskill_openings():
             ]
             db_update_trueskill(player_results, player_collection)
 
+def update_plays():
+    DB.trueskill_openings.ensure_index('cards')
+    for opening in DB.trueskill_openings.find():
+        key = opening['name']
+        cards = key[5:].split('+')
+        print cards
+        DB.trueskill_openings.update(
+            {'name': key},
+            {'$set': {'cards': cards}}
+        )
+

--- a/run_trueskill.py
+++ b/run_trueskill.py
@@ -3,7 +3,8 @@ con = get_mongo_connection()
 DB = con.test
 games = DB.games
 
-from trueskill.trueskill import db_update_trueskill
+from trueskill.trueskill import db_update_trueskill, SetParameters
+SetParameters(gamma=0.0001)
 
 def results_to_ranks(results):
     sorted_results = sorted(results)

--- a/run_trueskill.py
+++ b/run_trueskill.py
@@ -51,16 +51,7 @@ def run_trueskill_openings():
                           deck['turns'][1].get('buys', [])
                 opening.sort()
                 open_name = 'open:'+ ('+'.join(opening))
-                i = 2
-                while open_name in openings:
-                    # a cheap way to uniquify opening names.
-                    # Silver+Silver2 means you are the second player to
-                    # open Silver+Silver this game. *shrug*
-                    if i == 2:
-                        idx = openings.index(open_name)
-                        openings[idx] = 'open1:' + ('+'.join(opening))
-                    open_name = ('open%d:' % i) + ('+'.join(opening))
-                    i += 1
+                if open_name in openings:
                     dups = True
                 openings.append(open_name)
                 nturns = len(deck['turns'])
@@ -69,11 +60,11 @@ def run_trueskill_openings():
                 else:
                     vp = deck['points']
                 results.append((-vp, nturns))
-                teams.append([open_name])
+                teams.append([open_name, deck['name']])
             if not dups:
                 ranks = results_to_ranks(results)
                 team_results = [
-                    (team, [1.0], rank)
+                    (team, [0.5, 0.5], rank)
                     for team, rank in zip(teams, ranks)
                 ]
                 db_update_trueskill(team_results, collection)

--- a/trueskill/trueskill.py
+++ b/trueskill/trueskill.py
@@ -310,26 +310,36 @@ def SetParameters(beta=None, epsilon=None, draw_probability=None,
 
 SetParameters()
 
-def get_db_entry(player_name, collection):
-    entry = collection.find_one({'name': player_name})
+def get_db_entry(player_info, collection):
+    if isinstance(player_info, dict):
+        # pre-computed skill
+        if 'gamma' not in player_info:
+            player_info['gamma'] = GAMMA
+        return player_info
+    entry = collection.find_one({'name': player_info})
     if entry is None:
-        if player_name.startswith('open:'):
-            entry = {'mu': 0.0, 'sigma': INITIAL_SIGMA}
+        if player_info.startswith('open:'):
+            entry = {'mu': 0.0, 'sigma': INITIAL_SIGMA, 'gamma': 0.0001}
         else:
-            entry = {'mu': INITIAL_MU, 'sigma': INITIAL_SIGMA}
+            entry = {'mu': INITIAL_MU, 'sigma': INITIAL_SIGMA, 'gamma': GAMMA}
     return entry
 
-def get_skill(player_name, collection):
-    return get_db_entry(player_name, collection)['mu']
+def get_skill(player_info, collection):
+    return get_db_entry(player_info, collection)['mu']
 
-def get_stdev(player_name, collection):
-    return get_db_entry(player_name, collection)['sigma']
+def get_stdev(player_info, collection):
+    return get_db_entry(player_info, collection)['sigma']
 
-def set_db_entry(player_name, mu, sigma, collection):
+def get_gamma(player_info, collection):
+    return get_db_entry(player_info, collection)['gamma']
+
+def set_db_entry(player_name, mu, sigma, gamma, collection):
+    if isinstance(player_name, dict):
+        player_name = player_name['name']
     floor = mu - 3*sigma
     ceil = mu + 3*sigma
     collection.update({'name': player_name},
-                      {'$set': {'mu': mu, 'sigma': sigma,
+                      {'$set': {'mu': mu, 'sigma': sigma, 'gamma': gamma,
                                 'ceil': ceil, 'floor': floor}},
                       upsert=True)
 
@@ -351,7 +361,8 @@ def db_update_trueskill(team_results, collection):
   # Create each layer of factor nodes.  At the top we have priors
   # initialized to the player's current skill estimate.
   skill = [PriorFactor(s, Gaussian(mu=get_skill(pl, collection),
-                                   sigma=get_stdev(pl, collection) + GAMMA))
+                                   sigma=get_stdev(pl, collection) +
+                                         get_gamma(pl, collection)))
            for (s, pl) in zip(ss, players)]
   skill_to_perf = [LikelihoodFactor(s, p, BETA**2)
                    for (s, p) in zip(ss, ps)]
@@ -418,8 +429,9 @@ def db_update_trueskill(team_results, collection):
 
   for s, pl in zip(ss, players):
     mu, sigma = s.value.MuSigma()
-    set_db_entry(pl, mu, sigma, collection)
-    if sigma*3 < 10:
+    gamma = get_gamma(pl, collection)
+    set_db_entry(pl, mu, sigma, gamma, collection)
+    if isinstance(pl, basestring) and (mu - sigma*3) > 0 or (mu + sigma*3) < 0:
         print('%30s : %4.2f +- %4.2f' % (pl, mu, sigma*3))
 
 def AdjustPlayers(players):

--- a/trueskill/trueskill.py
+++ b/trueskill/trueskill.py
@@ -313,7 +313,10 @@ SetParameters()
 def get_db_entry(player_name, collection):
     entry = collection.find_one({'name': player_name})
     if entry is None:
-        entry = {'mu': INITIAL_MU, 'sigma': INITIAL_SIGMA}
+        if player_name.startswith('open:'):
+            entry = {'mu': 0.0, 'sigma': INITIAL_SIGMA}
+        else:
+            entry = {'mu': INITIAL_MU, 'sigma': INITIAL_SIGMA}
     return entry
 
 def get_skill(player_name, collection):
@@ -416,7 +419,7 @@ def db_update_trueskill(team_results, collection):
   for s, pl in zip(ss, players):
     mu, sigma = s.value.MuSigma()
     set_db_entry(pl, mu, sigma, collection)
-    if sigma*3 < 20:
+    if sigma*3 < 10:
         print('%30s : %4.2f +- %4.2f' % (pl, mu, sigma*3))
 
 def AdjustPlayers(players):


### PR DESCRIPTION
I implemented one of the to-do list items -- I evaluated opening buys using TrueSkill.

The player's skill rating (up to that point) is taken into account as an additional input (the player and the opening are a TrueSkill "team"). The opening ratings are centered at 0, so that they represent a number of skill points that you effectively gain or lose by playing that opening.

These results are already in the MongoDB, in the "trueskill_openings" collection. You can sort decreasing by "floor" or increasing by "ceil", to see the best and worst openings that people play. (The best opening is Chapel+Mountebank. Who knew?) However, I haven't written any sort of frontend or visualization for this data.

I don't think there's any particular significance to the 0 point -- perhaps as a baseline, all the ratings should have 0.581 subtracted from them, which is the average rating of Silver+Silver.
